### PR TITLE
Install protbuf-c instead of protobuf-compiler and protobuf-devel as …

### DIFF
--- a/rh-wasm-shim/Containerfile.wasm-shim
+++ b/rh-wasm-shim/Containerfile.wasm-shim
@@ -9,7 +9,7 @@
     
     ARG RUSTC_VERSION=1.80.0
     ARG TARGET=wasm32-unknown-unknown
-    RUN PKGS="rust-toolset llvm-toolset gcc-c++ gcc-toolset-12-binutils-gold openssl-devel perl git rust-std-static-${TARGET}" \
+    RUN PKGS="rust-toolset llvm-toolset gcc-c++ gcc-toolset-12-binutils-gold protobuf-c openssl-devel perl git rust-std-static-${TARGET}" \
     && dnf install --nodocs --assumeyes $PKGS \
     && rpm --verify --nogroup --nouser $PKGS \
     && yum -y clean all


### PR DESCRIPTION
…those containers are no longer available in UBI9.5