### PR TITLE
Enable automerge for Konflux Bot digest updates (PRs)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
     "packageRules": [
         {
+        "description": "Enable automerge for konflux bot digest updates only",
         "matchUpdateTypes": ["digest"],
         "automerge": true
         }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+    "packageRules": [
+        {
+        "matchUpdateTypes": ["digest"],
+        "automerge": true
+        }
+    ]
+}


### PR DESCRIPTION
Enable automerge for konflux bot PRs relating to submodule digest updates.

Uses base config from mintmaker, konflux.