### PR TITLE
Exchanging the build pipeline build task with higher memory limits

### DIFF
--- a/.tekton/rh-authorino-operator-bundle-pull-request.yaml
+++ b/.tekton/rh-authorino-operator-bundle-pull-request.yaml
@@ -229,9 +229,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-authorino-operator-bundle-push.yaml
+++ b/.tekton/rh-authorino-operator-bundle-push.yaml
@@ -225,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-authorino-operator-pull-request.yaml
+++ b/.tekton/rh-authorino-operator-pull-request.yaml
@@ -229,9 +229,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-authorino-operator-push.yaml
+++ b/.tekton/rh-authorino-operator-push.yaml
@@ -225,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-authorino-pull-request.yaml
+++ b/.tekton/rh-authorino-pull-request.yaml
@@ -228,9 +228,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-authorino-push.yaml
+++ b/.tekton/rh-authorino-push.yaml
@@ -224,9 +224,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-connectivity-link-operator-bundle-pull-request.yaml
+++ b/.tekton/rh-connectivity-link-operator-bundle-pull-request.yaml
@@ -228,9 +228,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-connectivity-link-operator-bundle-push.yaml
+++ b/.tekton/rh-connectivity-link-operator-bundle-push.yaml
@@ -224,9 +224,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-connectivity-link-operator-pull-request.yaml
+++ b/.tekton/rh-connectivity-link-operator-pull-request.yaml
@@ -228,9 +228,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-connectivity-link-operator-push.yaml
+++ b/.tekton/rh-connectivity-link-operator-push.yaml
@@ -224,9 +224,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-console-plugin-pull-request.yaml
+++ b/.tekton/rh-console-plugin-pull-request.yaml
@@ -236,9 +236,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-console-plugin-push.yaml
+++ b/.tekton/rh-console-plugin-push.yaml
@@ -232,9 +232,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-dns-operator-bundle-pull-request.yaml
+++ b/.tekton/rh-dns-operator-bundle-pull-request.yaml
@@ -230,9 +230,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-dns-operator-bundle-push.yaml
+++ b/.tekton/rh-dns-operator-bundle-push.yaml
@@ -226,9 +226,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-dns-operator-pull-request.yaml
+++ b/.tekton/rh-dns-operator-pull-request.yaml
@@ -229,9 +229,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-dns-operator-push.yaml
+++ b/.tekton/rh-dns-operator-push.yaml
@@ -225,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-limitador-operator-bundle-pull-request.yaml
+++ b/.tekton/rh-limitador-operator-bundle-pull-request.yaml
@@ -230,9 +230,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-limitador-operator-bundle-push.yaml
+++ b/.tekton/rh-limitador-operator-bundle-push.yaml
@@ -226,9 +226,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-limitador-operator-pull-request.yaml
+++ b/.tekton/rh-limitador-operator-pull-request.yaml
@@ -230,9 +230,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-limitador-operator-push.yaml
+++ b/.tekton/rh-limitador-operator-push.yaml
@@ -226,9 +226,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-limitador-pull-request.yaml
+++ b/.tekton/rh-limitador-pull-request.yaml
@@ -229,9 +229,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-limitador-push.yaml
+++ b/.tekton/rh-limitador-push.yaml
@@ -225,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-wasm-shim-pull-request.yaml
+++ b/.tekton/rh-wasm-shim-pull-request.yaml
@@ -229,9 +229,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-wasm-shim-push.yaml
+++ b/.tekton/rh-wasm-shim-push.yaml
@@ -225,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-6gb
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:cfd711876f21a55bb12c3c5745ecccf4429f2a33ba634f80d8c1eedce7fe2d26
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb@sha256:d58c88834215d265f776c7deb870e104e9ca53e26888713b307ac0c1042a23b3
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
**Why?** 
Increasing the limit from 4GB to 6GB should provide sufficient headroom for current and anticipated build processes, improving reliability.

Further information through Konflux Docs